### PR TITLE
Use a resource for git checkouts

### DIFF
--- a/cookbooks/dlamp/attributes/default.rb
+++ b/cookbooks/dlamp/attributes/default.rb
@@ -43,3 +43,4 @@ default['mysql']['bind_address'] = "0.0.0.0"
 
 # DLAMP
 default['dlamp_database'] = []
+default['dlamp']['git_checkout'] = []

--- a/cookbooks/dlamp/providers/git_checkout.rb
+++ b/cookbooks/dlamp/providers/git_checkout.rb
@@ -1,0 +1,56 @@
+
+def load_current_resource
+  #
+end
+
+action :create do
+  # whole sale make sure the destination is writeable
+  directory new_resource.destination do
+    mode "0777"
+  end
+
+  # add the git repo to known hosts so we don't have issues pulling things in
+  # ssh_known_hosts repo['fdqn'] do
+  #   user "vagrant"
+  # end
+
+  if !new_resource.deploy_key.empty?
+    # create a ssh key wrapper we can use if a deploy key is needed
+    file "/home/vagrant/#{new_resource.name}.git_wrapper.sh" do
+      owner "vagrant"
+      mode "0755"
+      content "#!/bin/sh\nexec /usr/bin/ssh -i /home/vagrant/.ssh/#{new_resource.name}.deploy_rsa \"$@\""
+    end
+
+    # create the key itself to be used
+    file "/home/vagrant/.ssh/#{new_resource.name}.deploy_rsa" do
+      owner "vagrant"
+      mode "0600"
+      content new_resource.deploy_key
+    end
+
+    # add this key to ssh config file
+    ssh_config new_resource.fdqn do
+      options 'User' => 'git', 'IdentityFile' => "/home/vagrant/.ssh/#{new_resource.name}.deploy_rsa"
+    end
+  end
+
+  git new_resource.destination do
+    repository new_resource.repo
+    revision new_resource.revision
+    user "vagrant"
+    if new_resource.deploy_key
+      ssh_wrapper "/home/vagrant/" + new_resource.name + ".git_wrapper.sh"
+    end
+    action :sync
+  end
+end
+
+action :delete do
+  if ::File.exist?(new_resource.destination)
+    file new_resource.destination do
+      action :delete
+    end
+    new_resource.updated_by_last_action(true)
+  end
+end

--- a/cookbooks/dlamp/recipes/git_checkout.rb
+++ b/cookbooks/dlamp/recipes/git_checkout.rb
@@ -21,60 +21,24 @@
 Chef::Log.info "Attempting to locate databag dlamp_git_checkout"
 
 if Chef::DataBag.list.key?('dlamp_git_checkout')
-  begin
-    repos = data_bag('dlamp_git_checkout').collect do |item|
-      repo = data_bag_item('dlamp_git_checkout', item)
-
-      # whole sale make sure the destination is writeable
-      directory "#{repo['destination']}" do
-        mode "0777"
-      end
-
-      # add the git repo to known hosts so we don't have issues pulling things in
-      ssh_known_hosts repo['fdqn'] do
-        user "vagrant"
-      end
-
-      if not repo['revision']
-        repo['revision'] = "HEAD"
-      end
-
-      if repo['deploy_key']
-        # create a ssh key wrapper we can use if a deploy key is needed
-        file "/home/vagrant/#{repo['id']}.git_wrapper.sh" do
-          owner "vagrant"
-          mode "0755"
-          content "#!/bin/sh\nexec /usr/bin/ssh -i /home/vagrant/.ssh/#{repo['id']}.deploy_rsa \"$@\""
-        end
-
-        # create the key itself to be used
-        file "/home/vagrant/.ssh/#{repo['id']}.deploy_rsa" do
-          owner "vagrant"
-          mode "0600"
-          content repo['deploy_key']
-        end
-
-        # add this key to ssh config file
-        ssh_config repo['fdqn'] do
-          options 'User' => 'git', 'IdentityFile' => "/home/vagrant/.ssh/#{repo['id']}.deploy_rsa"
-        end
-      end
-
-      git repo['destination'] do
-        repository repo['repo']
-        revision repo['revision']
-        user "vagrant"
-        if repo['deploy_key']
-          ssh_wrapper "/home/vagrant/" + repo['id'] + ".git_wrapper.sh"
-        end
-        action :sync
-      end
-
-      directory repo['destination'] do
-        mode "777"
-      end
+  repos = data_bag('dlamp_git_checkout').collect do |item|
+    repo = data_bag_item('dlamp_git_checkout', item)
+    dlamp_git_checkout repo['id'] do
+      destination repo['destination']
+      deploy_key repo['deploy_key']
+      repo repo['repo']
+      revision repo['revision']
+      fdqn repo['fdqn']
     end
-  rescue
-    Chef::Log.info "Could not load data bag 'dlamp_git_checkout'"
+  end
+end
+
+node['dlamp']['git_checkout'].each do |repo|
+  dlamp_git_checkout repo['id'] do
+    destination repo['destination']
+    deploy_key repo['deploy_key']
+    repo repo['repo']
+    revision repo['revision']
+    fdqn repo['fdqn']
   end
 end

--- a/cookbooks/dlamp/resources/git_checkout.rb
+++ b/cookbooks/dlamp/resources/git_checkout.rb
@@ -1,0 +1,8 @@
+actions :create, :delete
+default_action :create
+
+attribute :destination, kind_of: String
+attribute :deploy_key, kind_of: String, default: ''
+attribute :repo, kind_of: String
+attribute :revision, kind_of: String, default: 'master'
+attribute :fdqn, kind_of: String, default: 'master'


### PR DESCRIPTION
This allows easy creation from node config or a databag.

I think this solves your problem with the git_checkout recipe eating your checkouts.
